### PR TITLE
WIP: Update mixlib-install to render the install.sh for artifactory.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
 source "https://rubygems.org"
+
+gem "mixlib-install", github: "chef/mixlib-install", branch: "pw/windows"
+
 gemspec
 
 group :guard do

--- a/lib/kitchen/provisioner/base.rb
+++ b/lib/kitchen/provisioner/base.rb
@@ -62,11 +62,11 @@ module Kitchen
         sandbox_dirs = Dir.glob(File.join(sandbox_path, "*"))
 
         instance.transport.connection(state) do |conn|
-          conn.execute(install_command)
           conn.execute(init_command)
           info("Transferring files to #{instance.to_str}")
           conn.upload(sandbox_dirs, config[:root_path])
           debug("Transfer complete")
+          conn.execute(install_command)
           conn.execute(prepare_command)
           conn.execute(run_command)
         end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -26,6 +26,7 @@ require "kitchen/provisioner/chef/common_sandbox"
 require "kitchen/provisioner/chef/librarian"
 require "kitchen/util"
 require "mixlib/install"
+require "mixlib/install/script_generator"
 
 module Kitchen
 
@@ -86,6 +87,7 @@ module Kitchen
       # (see Base#create_sandbox)
       def create_sandbox
         super
+        prepare_installer_script
         Chef::CommonSandbox.new(config, sandbox_path, instance).populate
       end
 
@@ -105,18 +107,22 @@ module Kitchen
         shell_code_from_file(vars, "chef_base_init_command")
       end
 
-      # (see Base#install_command)
       def install_command
-        return unless config[:require_chef_omnibus]
-
-        version = config[:require_chef_omnibus].to_s.downcase
-
-        installer = Mixlib::Install.new(version, powershell_shell?, install_options)
-        config[:chef_omnibus_root] = installer.root
-        installer.install_command
+        "sudo /bin/sh #{File.join(config[:root_path], 'installer.sh')}"
       end
 
       private
+
+      # Prepares the installer script under the sandbox
+      # @api private
+      def prepare_installer_script
+        return unless config[:require_chef_omnibus] || config[:product_name]
+        install_script_path = File.join(sandbox_path, 'installer.sh')
+
+        File.open(install_script_path, "wb") do |file|
+          file.write(install_script_contents)
+        end
+      end
 
       # @return [Hash] an option hash for the install commands
       # @api private
@@ -259,6 +265,30 @@ module Kitchen
           %{$env:PATH},
           %{[System.Environment]::GetEnvironmentVariable("PATH","Machine")\n\n}
         ].join(" = ")
+      end
+
+      # @return [String] contents of the install script
+      # @api private
+      def install_script_contents
+        return unless config[:require_chef_omnibus] || config[:product_name]
+
+        # by default require_chef_omnibus is set to true. Check config[:product_name] first
+        # so that we can use it if configured.
+        if config[:product_name]
+          installer = Mixlib::Install.new({
+            product_name: config[:product_name],
+            product_version: config[:product_version],
+            channel: config[:channel].to_sym || :stable
+          })
+          config[:chef_omnibus_root] = installer.root
+          installer.install_command
+        elsif config[:require_chef_omnibus]
+          version = config[:require_chef_omnibus].to_s.downcase
+
+          installer = Mixlib::Install::ScriptGenerator.new(version, powershell_shell?, install_options)
+          config[:chef_omnibus_root] = installer.root
+          installer.install_command
+        end
       end
     end
   end

--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -287,6 +287,7 @@ module Kitchen
             channel: config[:channel].to_sym || :stable
           }.tap do |opts|
             opts[:shell_type] = :ps1 if powershell_shell?
+            opts[:architecture] = config[:architecture] if config[:architecture]
           end)
           config[:chef_omnibus_root] = installer.root
           installer.install_command

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh",         "~> 2.7", "< 2.10"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
-  gem.add_dependency "mixlib-install",  "~> 1.0"
+  # gem.add_dependency "mixlib-install",  "~> 1.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "winrm-transport", "~> 1.0"

--- a/test-kitchen.gemspec
+++ b/test-kitchen.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh",         "~> 2.7", "< 2.10"
   gem.add_dependency "safe_yaml",       "~> 1.0"
   gem.add_dependency "thor",            "~> 0.18"
-  gem.add_dependency "mixlib-install",  "~> 0.7"
+  gem.add_dependency "mixlib-install",  "~> 1.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "winrm-transport", "~> 1.0"


### PR DESCRIPTION
This is a preview PR for adding `product_name`, `product_version` and `channel` to test.

First some background. As we move towards CD for Chef products, we are standardizing how we download and install Chef products. In this standard, we will be using 3 things to refer to a Chef product:
- `product_name`: Any one of the keys in [here](https://github.com/chef-cookbooks/chef-ingredient/blob/master/PRODUCT_MATRIX.md).
- `product_version`: :latest, "latest" or a specific version number. 
- `channel`: :stable, :current or :unstable (available from Chef internal network only). 

We are collecting all the installation logic in [mixlib-install](https://github.com/chef/mixlib-install). One of the steps we are taking is to pull in `install.sh` into mixlib-install as well. 

This PR is working with https://github.com/chef/mixlib-install/commit/a905ae8cc101b57c768dc4d8f74cc150a184e6c6 to install Chef using these new paradigms. A few things to point out for the PR: 
- Previously we were rendering an `install_command` that fetches `install.sh` and runs it with sudo (based on `use_sudo` parameter). We are not going to download that script anymore but we still want to honor `use_sudo` parameter. Since we do not want to sprinkle sudo into the command that we are running, I needed to reorder install and prepare so that we can upload the installer script before calling install command.
- I have added 3 new config options so that we can introduce this functionality without breaking the compatibility for the old ones. We have moved the old code into `ScriptGenerator` class in mixlib-install and using the current parameters will use the existing code. The new parameters will be activated only when you are using new parameters. 

There a bunch of missing things from this PR namely: 
- Test updates.
- Documentation updates for new parameters.
- Warning / Deprecation messages for new / old parameters.

I would like to get some initial feedback before moving further down this path.
